### PR TITLE
Update files to point to go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: required
 go:
-  - 1.7.x
+  - 1.9.x
 go_import_path: github.com/getbread/goose
 language: go
 


### PR DESCRIPTION
_WIP_

### Ticket
January 2018 Infrastructure Sprint
https://docs.google.com/spreadsheets/u/1/d/1tm2xItqhBm7jJcWg8I8iKB8wyhvU1ojJzGtVh4pwhsk/edit#gid=89640368

### Associated PRs


### Description
Upgrading the go version to 1.9, more details on overall upgrade here: https://github.com/getbread/base/wiki/Upgrading-Go-Versions-of-Breadbox

